### PR TITLE
[feat] format zxid fields switchable to hex string

### DIFF
--- a/app/src/main/java/cc/cc1234/app/util/Formatters.java
+++ b/app/src/main/java/cc/cc1234/app/util/Formatters.java
@@ -44,4 +44,9 @@ public class Formatters {
             throw new RuntimeException(e);
         }
     }
+    
+    public static String longToHexString(long val) {
+        return "0x" + Long.toHexString(val);
+    }
+    
 }

--- a/app/src/main/java/cc/cc1234/app/vo/SwitchableTextFieldDatum.java
+++ b/app/src/main/java/cc/cc1234/app/vo/SwitchableTextFieldDatum.java
@@ -1,15 +1,14 @@
 package cc.cc1234.app.vo;
 
-
 public class SwitchableTextFieldDatum {
    
-    private String formatted;
+    private final String formatted;
     
-    private String raw;
+    private final String raw;
     
     private boolean showRaw = true;
     
-    public static SwitchableTextFieldDatum BLANK = new SwitchableTextFieldDatum("", "");
+    public static final SwitchableTextFieldDatum BLANK = new SwitchableTextFieldDatum("", "");
     
     public SwitchableTextFieldDatum(String raw, String formatted) {
         this.formatted = formatted;

--- a/app/src/main/java/cc/cc1234/app/vo/SwitchableTextFieldDatum.java
+++ b/app/src/main/java/cc/cc1234/app/vo/SwitchableTextFieldDatum.java
@@ -1,0 +1,23 @@
+package cc.cc1234.app.vo;
+
+
+public class SwitchableTextFieldDatum {
+   
+    private String formatted;
+    
+    private String raw;
+    
+    private boolean showRaw = true;
+    
+    public static SwitchableTextFieldDatum BLANK = new SwitchableTextFieldDatum("", "");
+    
+    public SwitchableTextFieldDatum(String raw, String formatted) {
+        this.formatted = formatted;
+        this.raw = raw;
+    }
+    
+    public synchronized String exchange() {
+        showRaw = !showRaw;
+        return showRaw ? raw : formatted;
+    }
+}

--- a/app/src/main/resources/fxml/NodeInfoView.fxml
+++ b/app/src/main/resources/fxml/NodeInfoView.fxml
@@ -32,8 +32,7 @@
                             <children>
                                 <HBox alignment="CENTER_LEFT" spacing="10.0" GridPane.rowIndex="5">
                                     <children>
-                                        <Text strokeType="OUTSIDE" strokeWidth="0.0" text="cZxid"
-                                              styleClass="black-text"/>
+                                        <Label fx:id="cZxidLabel" minWidth="40.0" text="cZxid" styleClass="black-text"/>
                                         <TextField fx:id="cZxidField" editable="false" styleClass="node-info-field"/>
                                     </children>
                                     <padding>
@@ -42,8 +41,7 @@
                                 </HBox>
                                 <HBox alignment="CENTER_LEFT" spacing="10.0" GridPane.rowIndex="4">
                                     <children>
-                                        <Text strokeType="OUTSIDE" strokeWidth="0.0" text="pZxid"
-                                              styleClass="black-text"/>
+                                        <Label fx:id="pZxidLabel" minWidth="40.0" text="pZxid" styleClass="black-text"/>
                                         <TextField fx:id="pZxidField" editable="false" styleClass="node-info-field"/>
                                     </children>
                                     <padding>
@@ -52,7 +50,7 @@
                                 </HBox>
                                 <HBox alignment="CENTER_LEFT" spacing="6.0" GridPane.rowIndex="1">
                                     <children>
-                                        <Label fx:id="mtimeLabel" minWidth="40.0" text="mtime" styleClass="black-text"/>
+                                        <Label fx:id="mtimeLabel" minWidth="42" text="mtime" styleClass="black-text"/>
                                         <TextField fx:id="mtimeField" editable="false" styleClass="node-info-field"/>
                                     </children>
                                     <padding>
@@ -61,8 +59,7 @@
                                 </HBox>
                                 <HBox alignment="CENTER_LEFT" spacing="10.0">
                                     <children>
-                                        <Text strokeType="OUTSIDE" strokeWidth="0.0" text="ephemeralOwner"
-                                              styleClass="black-text"/>
+                                        <Label fx:id="ephemeralOwnerLabel" minWidth="130.0" text="ephemeralOwner" styleClass="black-text"/>
                                         <TextField fx:id="ephemeralOwnerField" editable="false"
                                                    styleClass="node-info-field"/>
                                     </children>
@@ -81,8 +78,7 @@
                                 </HBox>
                                 <HBox alignment="CENTER_LEFT" spacing="10.0" GridPane.rowIndex="3">
                                     <children>
-                                        <Text strokeType="OUTSIDE" strokeWidth="0.0" text="mZxid"
-                                              styleClass="black-text"/>
+                                        <Label fx:id="mZxidLabel" minWidth="41.5" text="mZxid" styleClass="black-text"/>
                                         <TextField fx:id="mZxidField" editable="false" styleClass="node-info-field"/>
                                     </children>
                                     <padding>


### PR DESCRIPTION
Zookeeper officially log , display or name zxid as hex string，so I format zxid related fields (exactly  ephermalOwner, mZxid, pZxid, cZxid) to hex using source code from zookeeper (org.apache.zookeeper.cli.StatPrinter::print()) in the node info view.
```java
package org.apache.zookeeper.cli;

import java.io.PrintStream;
import java.util.Date;
import org.apache.zookeeper.data.Stat;

/**
 * utility for printing stat values s
 */
public class StatPrinter {

    protected PrintStream out;

    public StatPrinter(PrintStream out) {
        this.out = out;
    }

    public void print(Stat stat) {
        out.println("cZxid = 0x" + Long.toHexString(stat.getCzxid()));
        out.println("ctime = " + new Date(stat.getCtime()).toString());
        out.println("mZxid = 0x" + Long.toHexString(stat.getMzxid()));
        out.println("mtime = " + new Date(stat.getMtime()).toString());
        out.println("pZxid = 0x" + Long.toHexString(stat.getPzxid()));
        out.println("cversion = " + stat.getCversion());
        out.println("dataVersion = " + stat.getVersion());
        out.println("aclVersion = " + stat.getAversion());
        out.println("ephemeralOwner = 0x" + Long.toHexString(stat.getEphemeralOwner()));
        out.println("dataLength = " + stat.getDataLength());
        out.println("numChildren = " + stat.getNumChildren());
    }

}
```
![image](https://user-images.githubusercontent.com/94208776/206112576-f002cdd7-eb9e-4186-a11f-140a6111770b.png)

For backward compatiblility, these fields can also be switched back to long value when click on coodinate labels like ctime label do.



